### PR TITLE
Implemented to_rdf for DisjointClasses, DataAllValuesFrom and Disjoin…

### DIFF
--- a/funowl/dataproperty_axioms.py
+++ b/funowl/dataproperty_axioms.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import List, Union
 
+from rdflib import Graph, OWL
+
 from funowl.annotations import Annotation, Annotatable
 from funowl.base.list_support import empty_list
 from funowl.class_expressions import ClassExpression
@@ -70,6 +72,10 @@ class DisjointDataProperties((Annotatable)):
     def to_functional(self, w: FunctionalWriter) -> FunctionalWriter:
         self.list_cardinality(self.dataPropertyExpressions, 'exprs', 2)
         return self.annots(w, lambda: w.iter(self.dataPropertyExpressions))
+
+    def to_rdf(self, g: Graph) -> None:
+        self.add_triple(g, self.dataPropertyExpressions[0].to_rdf(g),
+                        OWL.propertyDisjointWith, self.dataPropertyExpressions[1].to_rdf(g))
 
 
 @dataclass

--- a/funowl/dataranges.py
+++ b/funowl/dataranges.py
@@ -22,6 +22,8 @@ restrictionValue := Literal
 from dataclasses import dataclass
 from typing import Union, List
 
+from rdflib import Graph, BNode
+
 from funowl.annotations import Annotation
 from funowl.identifiers import IRI
 from funowl.literals import Datatype

--- a/funowl/objectproperty_axioms.py
+++ b/funowl/objectproperty_axioms.py
@@ -123,7 +123,7 @@ class DisjointObjectProperties(Annotatable):
         return self.annots(w, lambda: w.iter(self.objectPropertyExpressions))
 
     def to_rdf(self, g: Graph) -> None:
-        self.add_triple(g, self.objectPropertyExpressions[0].to_rdf(g), OWL.propertyDisjointWtih,
+        self.add_triple(g, self.objectPropertyExpressions[0].to_rdf(g), OWL.propertyDisjointWith,
                         self.objectPropertyExpressions[1].to_rdf(g))
 
 @dataclass


### PR DESCRIPTION
…tDataProperties

1. In the DataAllValuesFrom class, the DataPropertyExpression is supposed to be a list, so I changed it to List[] typing. However, this probably broke the to_functional function. I'm not really sure on how to fix the to_functional function. The DataSomeValuesFrom has also the same problem, but I didn't implement the to_rdf function yet.

