### PR TITLE
remove disallowing rdflib 6.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 requests = "*"
 
 [packages]
-rdflib = ">=5.0.0, !=6.1.*"
+rdflib = ">=5.0.0"
 rdflib-shim = "*"
 pyjsg = ">=0.11.6"
 rfc3987 = "*"


### PR DESCRIPTION
I have some projects using owlfun that also use rdflib 6.1, I know the prefix ingestion is annoying, but it doesn't cause bugs - can we just make owlfun be less opinionated and let the user decide?